### PR TITLE
Finnish spelling alphabet

### DIFF
--- a/src/Encoder/SpellingAlphabet.js
+++ b/src/Encoder/SpellingAlphabet.js
@@ -115,7 +115,39 @@ const alphabetSpecs = [
       'Семь',   'Восемь',   'Девять',       'Точка'
     ],
     spaceWord: '(пробел)'
+  },
+  {
+    name: 'finnish',
+    label: 'Finnish (unofficial) spelling alphabet',
+    characters: 'abcdefghijklmnopqrstuvwxyzåäö0123456789',
+    words: [
+      'Aarne',      'Bertta',     'Celsius',    'Daavid',     'Eemeli',
+      'Faarao',     'Gideon',     'Heikki',     'Iivari',     'Jussi',
+      'Kalle',      'Lauri',      'Matti',      'Niilo',      'Otto',
+      'Paavo',      'Kuu',        'Risto',      'Sakari',     'Tyyne',
+      'Urho',       'Vihtori',    'Wiski',      'Äksä',       'Yrjö',
+      'Tseta',      'Åke',        'Äiti',       'Öljy',       'Nolla',
+      'Yksi',       'Kaksi',      'Kolme',      'Neljä',      'Viisi',
+      'Kuusi',      'Seitsemän',  'Kahdeksan',  'Yhdeksän'
+    ],
+    spaceWord: '(väli)'
+  },
+  {
+    name: 'finnish-nato',
+    label: 'Finnish Defence Forces\' spelling alphabet',
+    characters: 'abcdefghijklmnopqrstuvwxxyzåäö0123456789.',
+    words: [
+      'Alfa',     'Bravo',    'Charlie',  'Delta',    'Echo',     'Foxtrot',
+      'Golf',     'Hotel',    'India',    'Juliett',  'Kilo',     'Lima',
+      'Mike',     'November', 'Oscar',    'Papa',     'Quebec',   'Romeo',
+      'Sierra',   'Tango',    'Uniform',  'Victor',   'Whiskey',  'X-ray',
+      'Xray',     'Yankee',   'Zulu',     'Åke',      'Äiti',     'Öljy',
+      'Zero',     'One',      'Two',      'Three',    'Four',     'Five',
+      'Six',      'Seven',    'Eight',    'Nine',     'Stop'
+    ],
+    spaceWord: '(space)'
   }
+  
   /* eslint-enable no-multi-spaces */
 ]
 

--- a/src/Encoder/SpellingAlphabet.js
+++ b/src/Encoder/SpellingAlphabet.js
@@ -134,18 +134,18 @@ const alphabetSpecs = [
   },
   {
     name: 'finnish-nato',
-    label: 'Finnish Defence Forces\' spelling alphabet',
-    characters: 'abcdefghijklmnopqrstuvwxxyzåäö0123456789.',
+    label: 'Finnish Defence Forces\' spelling alphabet in national use.',
+    characters: 'abcdefghijklmnopqrstuvwxxyzåäö0123456789',
     words: [
       'Alfa',     'Bravo',    'Charlie',  'Delta',    'Echo',     'Foxtrot',
       'Golf',     'Hotel',    'India',    'Juliett',  'Kilo',     'Lima',
       'Mike',     'November', 'Oscar',    'Papa',     'Quebec',   'Romeo',
       'Sierra',   'Tango',    'Uniform',  'Victor',   'Whiskey',  'X-ray',
       'Xray',     'Yankee',   'Zulu',     'Åke',      'Äiti',     'Öljy',
-      'Zero',     'One',      'Two',      'Three',    'Four',     'Five',
-      'Six',      'Seven',    'Eight',    'Nine',     'Stop'
+      'Nolla',    'Yksi',     'Kaksi',    'Kolme',    'Neljä',    'Viisi',
+      'Kuusi',    'Seitsemän','Kahdeksan','Yhdeksän'
     ],
-    spaceWord: '(space)'
+    spaceWord: '(väli)'
   }
   
   /* eslint-enable no-multi-spaces */

--- a/test/Encoder/SpellingAlphabet.js
+++ b/test/Encoder/SpellingAlphabet.js
@@ -66,5 +66,29 @@ describe('SpellingAlphabetEncoder', () => EncoderTester.test(SpellingAlphabetEnc
       'Иван Харитон (пробел) Борис Ульяна Леонид Ольга Киловатт (пробел) Дмитрий Антон ' +
       '(пробел) Василий Игрек Павел Елена Йот (пробел) Человек Антон Юрий (пробел) Один Два ' +
       'Три (пробел) Четыре Пять Шесть (пробел) Семь Восемь Девять Ноль Точка'
+  },
+  {
+    settings: { alphabet: 'finnish' },
+    content: 'wieniläinen siouxia puhuva ökyzombi diggaa åsan roquefort-tacoja 123 456 7890',
+    expectedResult:
+      'Wiski Iivari Eemeli Niilo Iivari Lauri Äiti Iivari Niilo Eemeli ' +
+      'Niilo (väli) Sakari Iivari Otto Urho Äksä Iivari Aarne (väli) ' +
+      'Paavo Urho Heikki Urho Vihtori Aarne (väli) Öljy Kalle Yrjö Tseta ' +
+      'Otto Matti Bertta Iivari (väli) Daavid Iivari Gideon Gideon ' +
+      'Aarne Aarne (väli) Åke Sakari Aarne Niilo (väli) Risto Otto Kuu ' +
+      'Urho Eemeli Faarao Otto Risto Tyyne - Tyyne Aarne Celsius Otto ' +
+      'Jussi Aarne (väli) Yksi Kaksi Kolme (väli) Neljä Viisi Kuusi ' +
+      '(väli) Seitsemän Kahdeksan Yhdeksän Nolla'
+  },
+  {
+    settings: { alphabet: 'finnish-nato' },
+    content: 'wieniläinen siouxia puhuva ökyzombi diggaa åsan roquefort-tacoja 123 456 7890',
+    expectedResult:
+      'Whiskey India Echo November India Lima Äiti India November Echo November (väli) ' +
+      'Sierra India Oscar Uniform X-ray India Alfa (väli) Papa Uniform Hotel Uniform Victor Alfa (väli) ' +
+      'Öljy Kilo Yankee Zulu Oscar Mike Bravo India (väli) Delta India Golf Golf Alfa Alfa (väli) ' +
+      'Åke Sierra Alfa November (väli) ' +
+      'Romeo Oscar Quebec Uniform Echo Foxtrot Oscar Romeo Tango - Tango Alfa Charlie Oscar Juliett Alfa ' +
+      '(väli) Yksi Kaksi Kolme (väli) Neljä Viisi Kuusi (väli) Seitsemän Kahdeksan Yhdeksän Nolla'
   }
 ]))


### PR DESCRIPTION
PR adds support:

- Finnish unofficial radio alphabet commonly used  in ham radio communications
- Finnish version of NATO alphabet used by Finnish Defense Forces. FDF international operations use only the NATO alphabet, this version is used when communicating in Finnish 
