### PR TITLE
Update PolybiusSquare.js

### DIFF
--- a/src/Encoder/PolybiusSquare.js
+++ b/src/Encoder/PolybiusSquare.js
@@ -31,7 +31,7 @@ export default class PolybiusSquareEncoder extends Encoder {
       {
         name: 'alphabet',
         type: 'text',
-        value: 'abcdefghiklmnopqrstuvwxyz',
+        value: 'abcdefghijklmnopqrstuvwxyz',
         uniqueChars: true,
         minLength: 2,
         validateValue: this.validateAlphabetValue.bind(this),


### PR DESCRIPTION
'j' is missing in the default alfabet
