### PR TITLE
Add support for Polish spelling alphabet

### DIFF
--- a/src/Encoder/SpellingAlphabet.js
+++ b/src/Encoder/SpellingAlphabet.js
@@ -115,6 +115,23 @@ const alphabetSpecs = [
       'Семь',   'Восемь',   'Девять',       'Точка'
     ],
     spaceWord: '(пробел)'
+  },
+  {
+    name: 'polish-official',
+    label: 'Polish spelling alphabet ',
+    characters: 'abcćdefghijklłmnopqrsśtuvwxyzźż0123456789.',
+    words: [
+      'Adam',      'Barbara',     'Celina',    'Ćma',       'Dorota',  
+      'Edward',    'Filip',       'Gustaw',    'Henryk',    'Ignacy',  
+      'Józef',     'Karol',       'Ludwik',    'Łukasz',    'Marian',  
+      'Nikodem',   'Olga',        'Paweł',     'Quantum',   'Roman',  
+      'Stefan',    'Światowid',   'Tadeusz',   'Urszula',   'Violetta',  
+      'Walenty',   'Xawery',      'Ypsylon',   'Zygmunt',   'Źrebak',  
+      'Żaba',      'Zero',        'Jedynka',   'Dwa',       'Trzy',  
+      'Cztery',    'Piątka',      'Sześć',     'Siedem',   'Osiem',
+      'Dziewięć',  'kropka'
+    ],
+    spaceWord: '(spacja)'
   }
   /* eslint-enable no-multi-spaces */
 ]

--- a/test/Encoder/SpellingAlphabet.js
+++ b/test/Encoder/SpellingAlphabet.js
@@ -66,5 +66,15 @@ describe('SpellingAlphabetEncoder', () => EncoderTester.test(SpellingAlphabetEnc
       'Иван Харитон (пробел) Борис Ульяна Леонид Ольга Киловатт (пробел) Дмитрий Антон ' +
       '(пробел) Василий Игрек Павел Елена Йот (пробел) Человек Антон Юрий (пробел) Один Два ' +
       'Три (пробел) Четыре Пять Шесть (пробел) Семь Восемь Девять Ноль Точка'
+  },
+  {
+    settings: { alphabet: 'polish-official' },
+    content: 'pchnąć w tę łódź jeża lub ośm skrzyń fig.',
+    expectedResult:
+      'Paweł Celina Henryk Nikodem ą Ćma (spacja) Walenty (spacja) ' +
+      'Tadeusz ę (spacja) Łukasz ó Dorota Źrebak (spacja) ' +
+      'Józef Edward Żaba Adam (spacja) Ludwik Urszula Barbara (spacja) ' +
+      'Olga Światowid Marian (spacja) Stefan Karol Roman Zygmunt Ypsylon ' +
+      'ń (spacja) Filip Ignacy Gustaw kropka'
   }
 ]))


### PR DESCRIPTION
<!--
1. Please follow the contributing guidelines and styleguides.
2. Describe WHAT your changes do and WHY you'd like to include them.
3. Write tests for your changes.
4. Successfully run `npm build`.
-->
I added the Polish phonetic alphabet used for spelling of words mainly in radio communications.
Ref:
[Phonetic spelling in audio radio communications PL](https://pl.wikipedia.org/wiki/Literowanie_w_fonicznych_%C5%82%C4%85czno%C5%9Bciach_radiowych)
[Table of letter designations used for spelling by the polish Police](https://www.policja.pl/ftp/dzienniki_urzedowe/2007/dziennik_15_2007.pdf#page=22)

