### PR TITLE
Enigma S rotor II correct wiring (according to internet)

### DIFF
--- a/src/Encoder/Enigma.js
+++ b/src/Encoder/Enigma.js
@@ -282,7 +282,7 @@ const rotorTable = [
 
   // Enigma I "Sondermaschine"
   'I-S',        'I',          'veosirzujdqckgwypnxaflthmb', 'q',
-  'II-S',       'II',         'uemoatqlshpkcyfwjzbgvxindr', 'e',
+  'II-S',       'II',         'uemoatqlshpkcyfwjzbgvxidnr', 'e',
   'III-S',      'III',        'tzhxmbsipnurjfdkeqvcwglaoy', 'v',
   'UKW-S',      'UKW',        'ciagsndrbytpzfulvhekoqxwjm', '',
 


### PR DESCRIPTION
This PR fixes issue #147 by referencing the correct Enigma S rotor II wiring.
Ref. https://www.cryptomuseum.com/crypto/enigma/wiring.htm#12
